### PR TITLE
Change encoding of library.properties from UTF-8-BOM to UTF-8

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-﻿name=mobile bluetooth
+name=mobile bluetooth
 version=1.0
 author=Jae An
 maintainer=Jae An


### PR DESCRIPTION
The encoding of the file was causing installation of the library to fail.